### PR TITLE
Fix ADC config for fader

### DIFF
--- a/firmware/main.c
+++ b/firmware/main.c
@@ -131,7 +131,7 @@ void main(void) {
 
     RC0 = 1;
 
-    ANSEL = 0b10000000; //AN7/RC3 is analog
+    ANSEL = 0b11100000;  //AN5/RC1, AN6/RC2, AN7/RC3 are alanog
     ANSELH = 0b00000001; //AN8/RC6 is analog
 
     /* 16Tosc conversion clock, 6Tad acquisition time, ADC Result Right Justified */


### PR DESCRIPTION
This is more to show my question than actual PR.

It seems to me that the analog value read setting on the PIC18 Fader is incorrect.
This is something I noticed while debugging my own assembled SC1000, so how come this firmware is fine in other people's SC1000s?

I suspect that my assembly method may be incorrect. The current ADC reading is 102X on one side only when the fader goes to either end, otherwise both values are 0.
